### PR TITLE
Replace mantine with tailwind in chrome module

### DIFF
--- a/apps/chrome/package.json
+++ b/apps/chrome/package.json
@@ -18,11 +18,10 @@
     "typecheck": "tsc --noEmit --p tsconfig.json"
   },
   "dependencies": {
-    "@mantine/core": "^7.17.2",
-    "@mantine/hooks": "^7.17.2",
-    "@mantine/notifications": "^7.17.2",
+    "@tailwindcss/postcss": "^4.0.12",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "tailwindcss": "^4.0.12",
     "turndown": "^7.2.0"
   },
   "devDependencies": {
@@ -73,8 +72,6 @@
     "jest-html-reporter": "^3.10.2",
     "postcss": "^8.4.39",
     "postcss-loader": "^8.1.1",
-    "postcss-preset-mantine": "^1.15.0",
-    "postcss-simple-vars": "^7.0.1",
     "react-require": "^1.0.1",
     "rimraf": "^3.0.2 ",
     "storybook": "^8.4.7",

--- a/apps/chrome/postcss.config.cjs
+++ b/apps/chrome/postcss.config.cjs
@@ -1,14 +1,5 @@
 module.exports = {
   plugins: {
-    'postcss-preset-mantine': {},
-    'postcss-simple-vars': {
-      variables: {
-        'mantine-breakpoint-xs': '36em',
-        'mantine-breakpoint-sm': '48em',
-        'mantine-breakpoint-md': '62em',
-        'mantine-breakpoint-lg': '75em',
-        'mantine-breakpoint-xl': '88em',
-      },
-    },
+    '@tailwindcss/postcss': {},
   },
 };

--- a/apps/chrome/src/common/LoadingPanel.tsx
+++ b/apps/chrome/src/common/LoadingPanel.tsx
@@ -1,15 +1,14 @@
-import { Center, Container, Loader } from '@mantine/core';
 import { FC } from 'react';
 
-interface LoadingPanelProps {}
-
-const LoadingPanel: FC<LoadingPanelProps> = ({}) => {
+const LoadingPanel: FC = () => {
   return (
-    <Container>
-      <Center>
-        <Loader />
-      </Center>
-    </Container>
+    <div className="flex items-center justify-center p-6">
+      <div
+        className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-blue-600"
+        role="status"
+        aria-label="Loading"
+      />
+    </div>
   );
 };
 

--- a/apps/chrome/src/common/mantine.ts
+++ b/apps/chrome/src/common/mantine.ts
@@ -1,5 +1,0 @@
-import { MantineTheme } from '@mantine/core';
-
-export const MANTINE_THEME: Partial<MantineTheme> = {
-  autoContrast: true,
-};

--- a/apps/chrome/src/options.tsx
+++ b/apps/chrome/src/options.tsx
@@ -1,21 +1,15 @@
-import { Container, MantineProvider } from '@mantine/core';
-import '@mantine/core/styles.css';
-import { Notifications } from '@mantine/notifications';
 import { createRoot } from 'react-dom/client';
 
-import { MANTINE_THEME } from './common/mantine';
 import { OptionsProvider } from './contexts/OptionsContext';
 import Options from './options/Options';
+import './styles/tailwind.css';
 
 const root = createRoot(document.getElementById('options-root')!);
 
 root.render(
-  <MantineProvider theme={MANTINE_THEME}>
-    <Notifications />
-    <OptionsProvider>
-      <Container p="xl" size="xs">
-        <Options />
-      </Container>
-    </OptionsProvider>
-  </MantineProvider>
+  <OptionsProvider>
+    <div className="mx-auto max-w-sm p-8">
+      <Options />
+    </div>
+  </OptionsProvider>
 );

--- a/apps/chrome/src/options/Options.tsx
+++ b/apps/chrome/src/options/Options.tsx
@@ -1,4 +1,3 @@
-import { Button, Group, Stack, Switch, Text, Title } from '@mantine/core';
 import { FC } from 'react';
 
 import LoadingPanel from '../common/LoadingPanel';
@@ -12,27 +11,37 @@ const Options: FC = () => {
   }
 
   return (
-    <Stack gap="md" mt="sm">
-      <Title order={3}>Extension Options</Title>
-      <Text size="sm" c="dimmed">
-        Persisted to <code>chrome.storage.sync</code> under key <code>extension_options</code>.
-      </Text>
-      <Switch
-        label="Enable notifications"
-        checked={options.enableNotifications}
-        onChange={(event) => updateOptions({ enableNotifications: event.currentTarget.checked })}
-      />
-      <Group gap="sm">
-        <Button
-          size="compact-sm"
-          maw={150}
-          loading={savingOptions}
+    <div className="mt-3 flex flex-col gap-4">
+      <h2 className="text-lg font-semibold text-gray-900">Extension Options</h2>
+      <p className="text-sm text-gray-500">
+        Persisted to{' '}
+        <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-xs">
+          chrome.storage.sync
+        </code>{' '}
+        under key{' '}
+        <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-xs">extension_options</code>
+        .
+      </p>
+      <label className="flex items-center gap-2 text-sm text-gray-800">
+        <input
+          type="checkbox"
+          checked={options.enableNotifications}
+          onChange={(event) => updateOptions({ enableNotifications: event.currentTarget.checked })}
+          className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+        />
+        Enable notifications
+      </label>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={savingOptions}
           onClick={() => updateOptions(options)}
+          className="inline-flex max-w-[150px] items-center justify-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60"
         >
-          Save
-        </Button>
-      </Group>
-    </Stack>
+          {savingOptions ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
   );
 };
 

--- a/apps/chrome/src/side_panel.tsx
+++ b/apps/chrome/src/side_panel.tsx
@@ -1,17 +1,12 @@
-import { MantineProvider } from '@mantine/core';
-import { Notifications } from '@mantine/notifications';
 import { createRoot } from 'react-dom/client';
 
-import { MANTINE_THEME } from './common/mantine';
 import { TabsProvider } from './contexts/TabsContext';
 import SidePanel from './side_panel/SidePanel';
+import './styles/tailwind.css';
 
 const root = createRoot(document.getElementById('panel-root')!);
 root.render(
-  <MantineProvider theme={MANTINE_THEME}>
-    <Notifications limit={3} position="bottom-left" containerWidth={50} withinPortal />
-    <TabsProvider>
-      <SidePanel />
-    </TabsProvider>
-  </MantineProvider>
+  <TabsProvider>
+    <SidePanel />
+  </TabsProvider>
 );

--- a/apps/chrome/src/side_panel/SidePanel.tsx
+++ b/apps/chrome/src/side_panel/SidePanel.tsx
@@ -1,17 +1,3 @@
-import {
-  Anchor,
-  Button,
-  Code,
-  Container,
-  Group,
-  Stack,
-  Tabs,
-  Text,
-  TextInput,
-  Textarea,
-  Title,
-} from '@mantine/core';
-import '@mantine/core/styles.css';
 import { FC, useState } from 'react';
 
 import LoadingPanel from '../common/LoadingPanel';
@@ -19,6 +5,17 @@ import { GlobalConfig } from '../common/globalConfig';
 import { useTabs } from '../contexts/TabsContext';
 import { UserProfileProvider, useUserProfile } from '../contexts/UserProfileContext';
 import { useHtmlParser } from '../hooks/useHtmlParser';
+
+type TabKey = 'main' | 'profile' | 'about';
+
+const baseButton =
+  'inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60';
+
+const primaryButton = `${baseButton} bg-blue-600 text-white hover:bg-blue-700`;
+const lightRedButton = `${baseButton} bg-red-50 text-red-700 hover:bg-red-100`;
+
+const inputClass =
+  'block w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-50';
 
 const MainTab: FC = () => {
   const { currentTab } = useTabs();
@@ -40,28 +37,28 @@ const MainTab: FC = () => {
   };
 
   return (
-    <Stack gap="sm" mt="sm">
-      <Text size="sm" c="dimmed">
+    <div className="mt-3 flex flex-col gap-3">
+      <p className="text-sm text-gray-500">
         Round-trip the active page through the content script and render the Turndown-converted
         markdown below.
-      </Text>
-      <Button onClick={handleExtract} loading={parsing} disabled={!currentTab?.id}>
-        Extract page markdown
-      </Button>
-      {error && (
-        <Text size="sm" c="red">
-          {error}
-        </Text>
-      )}
-      <Textarea
+      </p>
+      <button
+        type="button"
+        onClick={handleExtract}
+        disabled={parsing || !currentTab?.id}
+        className={primaryButton}
+      >
+        {parsing ? 'Extracting…' : 'Extract page markdown'}
+      </button>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <textarea
         value={content}
         readOnly
-        autosize
-        minRows={8}
-        maxRows={20}
+        rows={12}
         placeholder="Markdown will appear here."
+        className={`${inputClass} resize-y font-mono text-xs`}
       />
-    </Stack>
+    </div>
   );
 };
 
@@ -93,74 +90,109 @@ const ProfileTab: FC = () => {
   };
 
   return (
-    <Stack gap="sm" mt="sm">
-      <Text size="sm" c="dimmed">
-        Stored locally in <Code>chrome.storage.local</Code>. No network calls.
-      </Text>
-      <TextInput
-        label="Display name"
-        value={displayName}
-        onChange={(e) => setDisplayName(e.currentTarget.value)}
-        placeholder="Ada Lovelace"
-      />
-      <TextInput
-        label="Email"
-        value={email}
-        onChange={(e) => setEmail(e.currentTarget.value)}
-        placeholder="ada@example.com"
-      />
-      <Group gap="sm">
-        <Button onClick={handleSave} loading={saving} disabled={!dirty}>
-          Save
-        </Button>
-        <Button variant="light" color="red" onClick={handleClear}>
+    <div className="mt-3 flex flex-col gap-3">
+      <p className="text-sm text-gray-500">
+        Stored locally in{' '}
+        <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-xs text-gray-800">
+          chrome.storage.local
+        </code>
+        . No network calls.
+      </p>
+      <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-gray-700">Display name</span>
+        <input
+          type="text"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.currentTarget.value)}
+          placeholder="Ada Lovelace"
+          className={inputClass}
+        />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-gray-700">Email</span>
+        <input
+          type="text"
+          value={email}
+          onChange={(e) => setEmail(e.currentTarget.value)}
+          placeholder="ada@example.com"
+          className={inputClass}
+        />
+      </label>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !dirty}
+          className={primaryButton}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        <button type="button" onClick={handleClear} className={lightRedButton}>
           Clear
-        </Button>
-      </Group>
-    </Stack>
+        </button>
+      </div>
+    </div>
   );
 };
 
 const AboutTab: FC = () => {
   return (
-    <Stack gap="sm" mt="sm">
-      <Text>
+    <div className="mt-3 flex flex-col gap-2">
+      <p className="text-sm">
         <strong>Chrome Extension Template</strong>
-      </Text>
-      <Text size="sm" c="dimmed">
+      </p>
+      <p className="text-sm text-gray-500">
         Version {GlobalConfig.version} ({GlobalConfig.environment})
-      </Text>
-      <Anchor component="button" type="button" onClick={() => chrome.runtime.openOptionsPage()}>
+      </p>
+      <button
+        type="button"
+        onClick={() => chrome.runtime.openOptionsPage()}
+        className="self-start text-sm text-blue-600 underline-offset-2 hover:underline"
+      >
         Open options
-      </Anchor>
-    </Stack>
+      </button>
+    </div>
   );
 };
 
 const SidePanel: FC = () => {
+  const [tab, setTab] = useState<TabKey>('main');
+
+  const tabs: { key: TabKey; label: string }[] = [
+    { key: 'main', label: 'Main' },
+    { key: 'profile', label: 'Profile' },
+    { key: 'about', label: 'About' },
+  ];
+
   return (
     <UserProfileProvider>
-      <Container fluid p="sm">
-        <Title order={4} mb="sm">
-          Chrome Extension Template
-        </Title>
-        <Tabs defaultValue="main">
-          <Tabs.List>
-            <Tabs.Tab value="main">Main</Tabs.Tab>
-            <Tabs.Tab value="profile">Profile</Tabs.Tab>
-            <Tabs.Tab value="about">About</Tabs.Tab>
-          </Tabs.List>
-          <Tabs.Panel value="main">
-            <MainTab />
-          </Tabs.Panel>
-          <Tabs.Panel value="profile">
-            <ProfileTab />
-          </Tabs.Panel>
-          <Tabs.Panel value="about">
-            <AboutTab />
-          </Tabs.Panel>
-        </Tabs>
-      </Container>
+      <div className="p-3">
+        <h1 className="mb-3 text-base font-semibold text-gray-900">Chrome Extension Template</h1>
+        <div className="flex border-b border-gray-200" role="tablist">
+          {tabs.map(({ key, label }) => {
+            const active = tab === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => setTab(key)}
+                className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+                  active
+                    ? 'border-blue-600 text-blue-600'
+                    : 'border-transparent text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+        {tab === 'main' && <MainTab />}
+        {tab === 'profile' && <ProfileTab />}
+        {tab === 'about' && <AboutTab />}
+      </div>
     </UserProfileProvider>
   );
 };

--- a/apps/chrome/src/styles/tailwind.css
+++ b/apps/chrome/src/styles/tailwind.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2014,7 +2014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.8.4":
   version: 7.27.0
   resolution: "@babel/runtime@npm:7.27.0"
   dependencies:
@@ -3081,7 +3081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/react@npm:^0.26.16, @floating-ui/react@npm:^0.26.28":
+"@floating-ui/react@npm:^0.26.16":
   version: 0.26.28
   resolution: "@floating-ui/react@npm:0.26.28"
   dependencies:
@@ -4166,57 +4166,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mantine/core@npm:^7.17.2":
-  version: 7.17.3
-  resolution: "@mantine/core@npm:7.17.3"
-  dependencies:
-    "@floating-ui/react": "npm:^0.26.28"
-    clsx: "npm:^2.1.1"
-    react-number-format: "npm:^5.4.3"
-    react-remove-scroll: "npm:^2.6.2"
-    react-textarea-autosize: "npm:8.5.6"
-    type-fest: "npm:^4.27.0"
-  peerDependencies:
-    "@mantine/hooks": 7.17.3
-    react: ^18.x || ^19.x
-    react-dom: ^18.x || ^19.x
-  checksum: 10c0/bf1282d3656436e7db8a7e1b516fbe3c8ad4be44e4c742852f69a9bb4e288d85db8c825a82171ac2cc46bc784d1a9a736896cc6a2679ea6d5f9ef07e8ad17883
-  languageName: node
-  linkType: hard
-
-"@mantine/hooks@npm:^7.17.2":
-  version: 7.17.3
-  resolution: "@mantine/hooks@npm:7.17.3"
-  peerDependencies:
-    react: ^18.x || ^19.x
-  checksum: 10c0/a823d8ee7ebc56547881601e09e9625900682380b96665fd07cdbe540e95045587681c2cb2c132138045e2d02fd47125dd93e83e9022074f80e88a8114428b28
-  languageName: node
-  linkType: hard
-
-"@mantine/notifications@npm:^7.17.2":
-  version: 7.17.3
-  resolution: "@mantine/notifications@npm:7.17.3"
-  dependencies:
-    "@mantine/store": "npm:7.17.3"
-    react-transition-group: "npm:4.4.5"
-  peerDependencies:
-    "@mantine/core": 7.17.3
-    "@mantine/hooks": 7.17.3
-    react: ^18.x || ^19.x
-    react-dom: ^18.x || ^19.x
-  checksum: 10c0/76ece2eed1069ee25a906426e0284aa344a7d8df29e4a07e643e2cbe12199bf3a597acfe5e46c42e7c251106f676f2f68946d76c3e08524084dd96a53b760892
-  languageName: node
-  linkType: hard
-
-"@mantine/store@npm:7.17.3":
-  version: 7.17.3
-  resolution: "@mantine/store@npm:7.17.3"
-  peerDependencies:
-    react: ^18.x || ^19.x
-  checksum: 10c0/21e12cbbe7433855e83baaadf9e03c1e04491b71d31f3fb0b2edd1f0198cf582436591b341d6c52a0693f60ba98d7e6ea92b7a1561bfc4b79d5352ba6d3a19cb
-  languageName: node
-  linkType: hard
-
 "@mdx-js/mdx@npm:^3.0.0":
   version: 3.1.0
   resolution: "@mdx-js/mdx@npm:3.1.0"
@@ -4941,9 +4890,6 @@ __metadata:
     "@babel/preset-react": "npm:^7.24.7"
     "@babel/preset-typescript": "npm:^7.24.7"
     "@chromatic-com/storybook": "npm:^1.6.0"
-    "@mantine/core": "npm:^7.17.2"
-    "@mantine/hooks": "npm:^7.17.2"
-    "@mantine/notifications": "npm:^7.17.2"
     "@repo/eslint-config": "npm:*"
     "@repo/jest-presets": "npm:*"
     "@repo/typescript-config": "npm:*"
@@ -4954,6 +4900,7 @@ __metadata:
     "@storybook/react": "npm:^8.4.7"
     "@storybook/react-vite": "npm:^8.4.7"
     "@storybook/test": "npm:^8.4.7"
+    "@tailwindcss/postcss": "npm:^4.0.12"
     "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
     "@types/babel__core": "npm:^7"
     "@types/babel__preset-env": "npm:^7"
@@ -4986,14 +4933,13 @@ __metadata:
     jest-html-reporter: "npm:^3.10.2"
     postcss: "npm:^8.4.39"
     postcss-loader: "npm:^8.1.1"
-    postcss-preset-mantine: "npm:^1.15.0"
-    postcss-simple-vars: "npm:^7.0.1"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-require: "npm:^1.0.1"
     rimraf: "npm:^3.0.2 "
     storybook: "npm:^8.4.7"
     style-loader: "npm:^4.0.0"
+    tailwindcss: "npm:^4.0.12"
     ts-jest: "npm:^29.1.0"
     ts-loader: "npm:^8.0.0"
     turndown: "npm:^7.2.0"
@@ -9941,13 +9887,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase-css@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "camelcase-css@npm:2.0.1"
-  checksum: 10c0/1a1a3137e8a781e6cbeaeab75634c60ffd8e27850de410c162cce222ea331cd1ba5364e8fb21c95e5ca76f52ac34b81a090925ca00a87221355746d049c6e273
-  languageName: node
-  linkType: hard
-
 "camelcase@npm:^5.0.0, camelcase@npm:^5.3.1":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
@@ -11785,13 +11724,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-node-es@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "detect-node-es@npm:1.1.0"
-  checksum: 10c0/e562f00de23f10c27d7119e1af0e7388407eb4b06596a25f6d79a360094a109ff285de317f02b090faae093d314cf6e73ac3214f8a5bb3a0def5bece94557fbe
-  languageName: node
-  linkType: hard
-
 "devlop@npm:^1.0.0, devlop@npm:^1.1.0":
   version: 1.1.0
   resolution: "devlop@npm:1.1.0"
@@ -11925,16 +11857,6 @@ __metadata:
   dependencies:
     utila: "npm:~0.4"
   checksum: 10c0/e96aa63bd8c6ee3cd9ce19c3aecfc2c42e50a460e8087114794d4f5ecf3a4f052b34ea3bf2d73b5d80b4da619073b49905e6d7d788ceb7814ca4c29be5354a11
-  languageName: node
-  linkType: hard
-
-"dom-helpers@npm:^5.0.1":
-  version: 5.2.1
-  resolution: "dom-helpers@npm:5.2.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.8.7"
-    csstype: "npm:^3.0.2"
-  checksum: 10c0/f735074d66dd759b36b158fa26e9d00c9388ee0e8c9b16af941c38f014a37fc80782de83afefd621681b19ac0501034b4f1c4a3bff5caa1b8667f0212b5e124c
   languageName: node
   linkType: hard
 
@@ -13905,7 +13827,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.7":
+"fast-glob@npm:^3.2.7":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -14479,13 +14401,6 @@ __metadata:
     hasown: "npm:^2.0.2"
     math-intrinsics: "npm:^1.1.0"
   checksum: 10c0/9f4ab0cf7efe0fd2c8185f52e6f637e708f3a112610c88869f8f041bb9ecc2ce44bf285dfdbdc6f4f7c277a5b88d8e94a432374d97cca22f3de7fc63795deb5d
-  languageName: node
-  linkType: hard
-
-"get-nonce@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "get-nonce@npm:1.0.1"
-  checksum: 10c0/2d7df55279060bf0568549e1ffc9b84bc32a32b7541675ca092dce56317cdd1a59a98dcc4072c9f6a980779440139a3221d7486f52c488e69dc0fd27b1efb162
   languageName: node
   linkType: hard
 
@@ -20833,17 +20748,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-js@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "postcss-js@npm:4.0.1"
-  dependencies:
-    camelcase-css: "npm:^2.0.1"
-  peerDependencies:
-    postcss: ^8.4.21
-  checksum: 10c0/af35d55cb873b0797d3b42529514f5318f447b134541844285c9ac31a17497297eb72296902967911bb737a75163441695737300ce2794e3bd8c70c13a3b106e
-  languageName: node
-  linkType: hard
-
 "postcss-loader@npm:^8.1.1":
   version: 8.1.1
   resolution: "postcss-loader@npm:8.1.1"
@@ -20861,20 +20765,6 @@ __metadata:
     webpack:
       optional: true
   checksum: 10c0/86cde94cd4c7c39892ef9bd4bf09342f422a21789654038694cf2b23c37c0ed9550c73608f656426a6631f0ade1eca82022781831e93d5362afe2f191388b85e
-  languageName: node
-  linkType: hard
-
-"postcss-mixins@npm:^9.0.4":
-  version: 9.0.4
-  resolution: "postcss-mixins@npm:9.0.4"
-  dependencies:
-    fast-glob: "npm:^3.2.11"
-    postcss-js: "npm:^4.0.0"
-    postcss-simple-vars: "npm:^7.0.0"
-    sugarss: "npm:^4.0.1"
-  peerDependencies:
-    postcss: ^8.2.14
-  checksum: 10c0/6bb90bd15bb4a06e8f50b36b38f24bba8350cdb9f1d9690e97a9610619da9fc22cdccfc81aa628bef60490cce35f76ceac7602062f5895b30d72123684016a93
   languageName: node
   linkType: hard
 
@@ -20922,29 +20812,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-nested@npm:^6.0.1":
-  version: 6.2.0
-  resolution: "postcss-nested@npm:6.2.0"
-  dependencies:
-    postcss-selector-parser: "npm:^6.1.1"
-  peerDependencies:
-    postcss: ^8.2.14
-  checksum: 10c0/7f9c3f2d764191a39364cbdcec350f26a312431a569c9ef17408021424726b0d67995ff5288405e3724bb7152a4c92f73c027e580ec91e798800ed3c52e2bc6e
-  languageName: node
-  linkType: hard
-
-"postcss-preset-mantine@npm:^1.15.0":
-  version: 1.17.0
-  resolution: "postcss-preset-mantine@npm:1.17.0"
-  dependencies:
-    postcss-mixins: "npm:^9.0.4"
-    postcss-nested: "npm:^6.0.1"
-  peerDependencies:
-    postcss: ">=8.0.0"
-  checksum: 10c0/9410196f8c9b6389f376abe04b732b92179859b195d1422d02e94e46fca1503272b553993727af396cddc6c094a162d73a9a8fd1f85bd3ac2c41135c9365210a
-  languageName: node
-  linkType: hard
-
 "postcss-selector-parser@npm:6.0.10":
   version: 6.0.10
   resolution: "postcss-selector-parser@npm:6.0.10"
@@ -20955,16 +20822,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:^6.1.1":
-  version: 6.1.2
-  resolution: "postcss-selector-parser@npm:6.1.2"
-  dependencies:
-    cssesc: "npm:^3.0.0"
-    util-deprecate: "npm:^1.0.2"
-  checksum: 10c0/523196a6bd8cf660bdf537ad95abd79e546d54180f9afb165a4ab3e651ac705d0f8b8ce6b3164fb9e3279ce482c5f751a69eb2d3a1e8eb0fd5e82294fb3ef13e
-  languageName: node
-  linkType: hard
-
 "postcss-selector-parser@npm:^7.0.0":
   version: 7.1.0
   resolution: "postcss-selector-parser@npm:7.1.0"
@@ -20972,15 +20829,6 @@ __metadata:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
   checksum: 10c0/0fef257cfd1c0fe93c18a3f8a6e739b4438b527054fd77e9a62730a89b2d0ded1b59314a7e4aaa55bc256204f40830fecd2eb50f20f8cb7ab3a10b52aa06c8aa
-  languageName: node
-  linkType: hard
-
-"postcss-simple-vars@npm:^7.0.0, postcss-simple-vars@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "postcss-simple-vars@npm:7.0.1"
-  peerDependencies:
-    postcss: ^8.2.1
-  checksum: 10c0/b59c750b2f406a18b133184144b5ffefbd21a2179c5bf5d54651269c0b6bb0110c2bbed33a9161d8b93f8a11cf7725da0a65653e7c2786c8a59f937591115a33
   languageName: node
   linkType: hard
 
@@ -21572,55 +21420,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-number-format@npm:^5.4.3":
-  version: 5.4.3
-  resolution: "react-number-format@npm:5.4.3"
-  peerDependencies:
-    react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/0d0c597c880e4abe8b1c3d4820ae8a5b8bd7c5fdd75011aedfb07d0d0311c0c45b5c3984b58c9c64a96a4570dee43adb4f0065e4e7b034b68118e338ad1c0eba
-  languageName: node
-  linkType: hard
-
 "react-refresh@npm:^0.14.0, react-refresh@npm:^0.14.2":
   version: 0.14.2
   resolution: "react-refresh@npm:0.14.2"
   checksum: 10c0/875b72ef56b147a131e33f2abd6ec059d1989854b3ff438898e4f9310bfcc73acff709445b7ba843318a953cb9424bcc2c05af2b3d80011cee28f25aef3e2ebb
-  languageName: node
-  linkType: hard
-
-"react-remove-scroll-bar@npm:^2.3.7":
-  version: 2.3.8
-  resolution: "react-remove-scroll-bar@npm:2.3.8"
-  dependencies:
-    react-style-singleton: "npm:^2.2.2"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/9a0675c66cbb52c325bdbfaed80987a829c4504cefd8ff2dd3b6b3afc9a1500b8ec57b212e92c1fb654396d07bbe18830a8146fe77677d2a29ce40b5e1f78654
-  languageName: node
-  linkType: hard
-
-"react-remove-scroll@npm:^2.6.2":
-  version: 2.6.3
-  resolution: "react-remove-scroll@npm:2.6.3"
-  dependencies:
-    react-remove-scroll-bar: "npm:^2.3.7"
-    react-style-singleton: "npm:^2.2.3"
-    tslib: "npm:^2.1.0"
-    use-callback-ref: "npm:^1.3.3"
-    use-sidecar: "npm:^1.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/068e9704ff26816fffc4c8903e2c6c8df7291ee08615d7c1ab0cf8751f7080e2c5a5d78ef5d908b11b9cfc189f176d312e44cb02ea291ca0466d8283b479b438
   languageName: node
   linkType: hard
 
@@ -21634,50 +21437,6 @@ __metadata:
     "@babel/core": ^7.5.5
     react: ^16.8.6
   checksum: 10c0/3fa28c04ce5efd64d3a5328d58f6079586f94bfebfb2386336f74e24ab6b7dc7b587248e65ab003a2c09b87d132d0dde7bc8ad57c50f0e91fad6bdbe75291de8
-  languageName: node
-  linkType: hard
-
-"react-style-singleton@npm:^2.2.2, react-style-singleton@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "react-style-singleton@npm:2.2.3"
-  dependencies:
-    get-nonce: "npm:^1.0.0"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/841938ff16d16a6b76895f4cb2e1fea957e5fe3b30febbf03a54892dae1c9153f2383e231dea0b3ba41192ad2f2849448fa859caccd288943bce32639e971bee
-  languageName: node
-  linkType: hard
-
-"react-textarea-autosize@npm:8.5.6":
-  version: 8.5.6
-  resolution: "react-textarea-autosize@npm:8.5.6"
-  dependencies:
-    "@babel/runtime": "npm:^7.20.13"
-    use-composed-ref: "npm:^1.3.0"
-    use-latest: "npm:^1.2.1"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/652d290d316c55a253507ecf65ca27f2162801dace10c715f2241203e81d82e9de6d282095b758b26c6bc9e1af9ca552cab5c3a361b230e5fcf25bec31e1bd25
-  languageName: node
-  linkType: hard
-
-"react-transition-group@npm:4.4.5":
-  version: 4.4.5
-  resolution: "react-transition-group@npm:4.4.5"
-  dependencies:
-    "@babel/runtime": "npm:^7.5.5"
-    dom-helpers: "npm:^5.0.1"
-    loose-envify: "npm:^1.4.0"
-    prop-types: "npm:^15.6.2"
-  peerDependencies:
-    react: ">=16.6.0"
-    react-dom: ">=16.6.0"
-  checksum: 10c0/2ba754ba748faefa15f87c96dfa700d5525054a0141de8c75763aae6734af0740e77e11261a1e8f4ffc08fd9ab78510122e05c21c2d79066c38bb6861a886c82
   languageName: node
   linkType: hard
 
@@ -24097,15 +23856,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sugarss@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "sugarss@npm:4.0.1"
-  peerDependencies:
-    postcss: ^8.3.3
-  checksum: 10c0/18b78c8839ab9eea9681366223277e10adf6b1dd54e7b64fbdae3a1234eedcc16a772bb62c8f3dc9665acc07496981e24bf773c8c362b5f294b9b1e12fbe58aa
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
@@ -24997,13 +24747,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.27.0":
-  version: 4.39.0
-  resolution: "type-fest@npm:4.39.0"
-  checksum: 10c0/6075dfb875fdf6319d2a62fb77663b8f551882003e53b2a14e345c87f2bc1825d616214c5b9f0ae1151e54cedf11b7d2ca7d95f891431ad8c602cf6da1becd6e
-  languageName: node
-  linkType: hard
-
 "typed-array-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "typed-array-buffer@npm:1.0.2"
@@ -25625,75 +25368,6 @@ __metadata:
     punycode: "npm:^1.4.1"
     qs: "npm:^6.12.3"
   checksum: 10c0/cc93405ae4a9b97a2aa60ca67f1cb1481c0221cb4725a7341d149be5e2f9cfda26fd432d64dbbec693d16593b68b8a46aad8e5eab21f814932134c9d8620c662
-  languageName: node
-  linkType: hard
-
-"use-callback-ref@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "use-callback-ref@npm:1.3.3"
-  dependencies:
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/f887488c6e6075cdad4962979da1714b217bcb1ee009a9e57ce9a844bcfc4c3a99e93983dfc2e5af9e0913824d24e730090ff255e902c516dcb58d2d3837e01c
-  languageName: node
-  linkType: hard
-
-"use-composed-ref@npm:^1.3.0":
-  version: 1.4.0
-  resolution: "use-composed-ref@npm:1.4.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/c77e0cba9579b7746d52feaf3ce77d8c345f266c9c1ef46584ae68f54646537c87b2ad97f5219a4b1db52f97ec2905e88e5b146add1f28f7e457bd52ca1b93cf
-  languageName: node
-  linkType: hard
-
-"use-isomorphic-layout-effect@npm:^1.1.1":
-  version: 1.2.0
-  resolution: "use-isomorphic-layout-effect@npm:1.2.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/2e4bdee68d65893b37e716ebdcc111550775189c80e662eda87d6f5b54dc431d3383a18914ea01a893ee5478902a878012713eaebcacbb6611ab88c463accb83
-  languageName: node
-  linkType: hard
-
-"use-latest@npm:^1.2.1":
-  version: 1.3.0
-  resolution: "use-latest@npm:1.3.0"
-  dependencies:
-    use-isomorphic-layout-effect: "npm:^1.1.1"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/067c648814ad0c1f1e89d2d0e496254b05c4bed6a34e23045b4413824222aab08fd803c59a42852acc16830c17567d03f8c90af0a62be2f4e4b931454d079798
-  languageName: node
-  linkType: hard
-
-"use-sidecar@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "use-sidecar@npm:1.1.3"
-  dependencies:
-    detect-node-es: "npm:^1.1.0"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/161599bf921cfaa41c85d2b01c871975ee99260f3e874c2d41c05890d41170297bdcf314bc5185e7a700de2034ac5b888e3efc8e9f35724f4918f53538d717c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Drop Mantine (`@mantine/core`, `@mantine/hooks`, `@mantine/notifications`) plus `postcss-preset-mantine` / `postcss-simple-vars` from `apps/chrome`
- Rewrite `SidePanel`, `Options`, and `LoadingPanel` as plain React components styled with Tailwind v4
- Add `tailwindcss` + `@tailwindcss/postcss`, a minimal `src/styles/tailwind.css`, and update `postcss.config.cjs`

## Test plan
- [ ] `yarn workspace @repo/chrome-ext typecheck`
- [ ] `yarn workspace @repo/chrome-ext build-prod`
- [ ] Load `dist/` as an unpacked extension and verify side panel + options render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)