### PR TITLE
Rename ClerkUser to User and switch id to cuid string

### DIFF
--- a/apps/web/src/lib/db/__integrationTests__/database.test.ts
+++ b/apps/web/src/lib/db/__integrationTests__/database.test.ts
@@ -2,69 +2,46 @@ import '@tests/integration-tests';
 
 describe('Database Integration Tests', () => {
   beforeEach(async () => {
-    await global.testPrisma.clerkUser.deleteMany();
+    await global.testPrisma.user.deleteMany();
   });
 
-  it('creates and retrieves a ClerkUser', async () => {
+  it('creates and retrieves a User', async () => {
     const userData = {
-      user_id: 'user_test123',
       email: 'test@example.com',
       name: 'Test User',
     };
 
-    const createdUser = await global.testPrisma.clerkUser.create({
+    const createdUser = await global.testPrisma.user.create({
       data: userData,
     });
 
+    expect(createdUser.id).toBeTruthy();
     expect(createdUser.email).toBe(userData.email);
     expect(createdUser.name).toBe(userData.name);
-    expect(createdUser.user_id).toBe(userData.user_id);
 
-    const retrievedUser = await global.testPrisma.clerkUser.findUnique({
+    const retrievedUser = await global.testPrisma.user.findUnique({
       where: { email: userData.email },
     });
 
     expect(retrievedUser).not.toBeNull();
+    expect(retrievedUser?.id).toBe(createdUser.id);
     expect(retrievedUser?.email).toBe(createdUser.email);
     expect(retrievedUser?.name).toBe(createdUser.name);
-    expect(retrievedUser?.user_id).toBe(createdUser.user_id);
   });
 
   it('handles unique email constraint', async () => {
     const userData = {
-      user_id: 'user_unique1',
       email: 'duplicate@example.com',
       name: 'Test User',
     };
 
-    await global.testPrisma.clerkUser.create({ data: userData });
+    await global.testPrisma.user.create({ data: userData });
 
     await expect(
-      global.testPrisma.clerkUser.create({
+      global.testPrisma.user.create({
         data: {
-          user_id: 'user_unique2',
           email: 'duplicate@example.com',
           name: 'Another User',
-        },
-      })
-    ).rejects.toThrow();
-  });
-
-  it('handles unique user_id constraint', async () => {
-    const userData = {
-      user_id: 'user_duplicate',
-      email: 'first@example.com',
-      name: 'First User',
-    };
-
-    await global.testPrisma.clerkUser.create({ data: userData });
-
-    await expect(
-      global.testPrisma.clerkUser.create({
-        data: {
-          user_id: 'user_duplicate',
-          email: 'second@example.com',
-          name: 'Second User',
         },
       })
     ).rejects.toThrow();

--- a/packages/database/prisma/migrations/20260613172633_rename_clerk_user_to_user/down.sql
+++ b/packages/database/prisma/migrations/20260613172633_rename_clerk_user_to_user/down.sql
@@ -1,0 +1,25 @@
+-- DropTable
+DROP TABLE "User";
+
+-- CreateTable
+CREATE TABLE "ClerkUser" (
+    "id" BIGSERIAL NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "image" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ClerkUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ClerkUser_user_id_key" ON "ClerkUser"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ClerkUser_email_key" ON "ClerkUser"("email");
+
+-- CreateIndex
+CREATE INDEX "clerk_user_index_on_user_id" ON "ClerkUser"("user_id");
+

--- a/packages/database/prisma/migrations/20260613172633_rename_clerk_user_to_user/migration.sql
+++ b/packages/database/prisma/migrations/20260613172633_rename_clerk_user_to_user/migration.sql
@@ -1,5 +1,5 @@
--- CreateSchema
-CREATE SCHEMA IF NOT EXISTS "public";
+-- DropTable
+DROP TABLE "ClerkUser";
 
 -- CreateTable
 CREATE TABLE "User" (

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -10,14 +10,11 @@ generator client {
   provider = "prisma-client-js"
 }
 
-model ClerkUser {
-  id         BigInt   @id @default(autoincrement())
-  user_id    String   @unique
+model User {
+  id         String   @id @default(cuid())
   name       String
   email      String   @unique
   image      String?
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
-
-  @@index([user_id], name: "clerk_user_index_on_user_id")
 }


### PR DESCRIPTION
## Summary
Prisma schema changes to the user model:
- **Rename** the `ClerkUser` model/table to `User`.
- **Change** the `id` column from an autoincrementing `BigInt` to a `cuid` `String`.
- **Remove** the `user_id` column (and its `clerk_user_index_on_user_id` index).

## Changes
- `packages/database/prisma/schema.prisma` — updated model definition.
- New migration `20260613172633_rename_clerk_user_to_user` (up + down). The id type change is incompatible with an in-place alter, so the migration drops and recreates the table.
- `packages/database/prisma/schema_dump.sql` — regenerated.
- `apps/web/.../__integrationTests__/database.test.ts` — updated to the new model (`user`) and dropped the `user_id` assertions/test.

## Notes
- Migration SQL was generated offline (datamodel-to-datamodel diff); no migrations were applied to the live database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)